### PR TITLE
feat: Connect H2 database and create model/repository layer

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -18,6 +18,7 @@ target/
 *.iws
 *.iml
 *.ipr
+.env
 
 ### NetBeans ###
 /nbproject/private/

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,1 +1,10 @@
 spring.application.name=panela-amiga
+
+spring.datasource.url=${DATABASE_URL}
+spring.datasource.driver=org.h2.Driver
+spring.datasource.username=${DATABASE_USERNAME}
+spring.datasource.password=${DATABASE_PASSWORD}
+
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.h2.console.enabled=true


### PR DESCRIPTION
This pull request includes the initial setup of the backend, including:

- Configured the H2 in-memory database in `application.properties`
- Created the `ReceitaModel` entity with `CategoriaReceita` enum
- Added the `ReceitaRepository` interface extending `JpaRepository`

This sets the foundation for further development of the recipe-related endpoints.
